### PR TITLE
loadaf.R: use c11 plugin

### DIFF
--- a/R/loadaf.R
+++ b/R/loadaf.R
@@ -245,7 +245,7 @@ read.sync <- function(file, gen, repl, polarization=c("minor", "rising", "refere
 
   cat("Extracting biallelic counts ...\n")
 
-  cppFunction({"NumericMatrix Sync2Cnts(CharacterVector sync) {
+  cppFunction(plugins=c("cpp11"),{"NumericMatrix Sync2Cnts(CharacterVector sync) {
     NumericMatrix resMat(sync.length(), 4);
 
     std::string current;


### PR DESCRIPTION
Quick fix to use C++11 standard (on which read.sync relies) for Rcpp.